### PR TITLE
Vault asset selector, mint and associate

### DIFF
--- a/.env
+++ b/.env
@@ -7,5 +7,5 @@ NEXT_PUBLIC_WALLET_DEFI_APP_URL="http://localhost:3000/"
 NEXT_PUBLIC_WALLET_DEFI_APP_ICON="some-image-url.png"
 
 SYNC_CONTRACTS_IGNORE=StakingToken;Share;RewardToken
-SYNC_CONTRACTS_ABI_PATH=https://raw.githubusercontent.com/web3-nomad/accelerator-defi-EIP/main/data/abis
-SYNC_CONTRACTS_SOURCE_URL=https://raw.githubusercontent.com/web3-nomad/accelerator-defi-EIP/main/data/deployments/chain-296.json
+SYNC_CONTRACTS_ABI_PATH=https://raw.githubusercontent.com/hashgraph/hedera-accelerator-defi-eip/main/data/abis
+SYNC_CONTRACTS_SOURCE_URL=https://raw.githubusercontent.com/hashgraph/hedera-accelerator-defi-eip/main/data/deployments/chain-296.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-dom": "^18",
         "react-redux": "^9.1.0",
         "react-router-dom": "^6.23.0",
+        "react-use": "^17.5.1",
         "viem": "^2.7.22",
         "wagmi": "^2.5.7",
         "web3": "^4.7.0"
@@ -8459,6 +8460,11 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -10882,6 +10888,11 @@
         "zod": "3.22.4"
       }
     },
+    "node_modules/@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
+    },
     "node_modules/@zag-js/dom-query": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.16.0.tgz",
@@ -12703,6 +12714,34 @@
         "tiny-invariant": "^1.0.6"
       }
     },
+    "node_modules/css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
@@ -13286,7 +13325,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
       "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
-      "peer": true,
       "dependencies": {
         "stackframe": "^1.3.4"
       }
@@ -14347,6 +14385,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
+    "node_modules/fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
@@ -14368,6 +14411,11 @@
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -15432,6 +15480,11 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
+    },
     "node_modules/i18next": {
       "version": "23.10.1",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.10.1.tgz",
@@ -15568,6 +15621,14 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -16464,6 +16525,11 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
+    },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
@@ -17478,6 +17544,11 @@
       "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
       "peer": true
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -18271,6 +18342,30 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
       "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew=="
+    },
+    "node_modules/nano-css": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.2.tgz",
+      "integrity": "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "css-tree": "^1.1.2",
+        "csstype": "^3.1.2",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^7.0.1",
+        "rtl-css-js": "^1.16.1",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/nano-css/node_modules/stylis": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -20316,6 +20411,50 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "peerDependencies": {
+        "react": "*",
+        "tslib": "*"
+      }
+    },
+    "node_modules/react-use": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.5.1.tgz",
+      "integrity": "sha512-LG/uPEVRflLWMwi3j/sZqR00nF6JGqTTDblkXK2nzXsIvij06hXl1V/MZIlwj1OKIQUtlh1l9jK8gLsRyCQxMg==",
+      "dependencies": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.6.2",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/react-use/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/react-use/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -20552,6 +20691,11 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
       "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -20733,6 +20877,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -20833,6 +20985,17 @@
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/secp256k1": {
@@ -21042,6 +21205,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
+      "engines": {
+        "node": ">=6.9"
       }
     },
     "node_modules/setimmediate": {
@@ -21381,6 +21552,14 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "peer": true
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -21405,8 +21584,34 @@
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-      "peer": true
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.10",
@@ -21964,6 +22169,14 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "peer": true
     },
+    "node_modules/throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -22048,6 +22261,11 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "node_modules/ts-typed-events": {
       "version": "3.0.0",

--- a/src/components/eip4626/User.tsx
+++ b/src/components/eip4626/User.tsx
@@ -7,33 +7,93 @@ import { VaultInfo } from "@/components/eip4626/user/VaultInfo";
 import { VaultDeposit } from "@/components/eip4626/user/VaultDeposit";
 import { Eip4626Context } from "@/contexts/Eip4626Context";
 import { VaultAddReward } from "@/components/eip4626/user/VaultAddReward";
+import { MintAssetToken } from "@/components/eip4626/user/MintAssetToken";
+import { useReadHederaVaultAssetQueries } from "@/hooks/eip4626/useReadHederaVaultAsset";
+import { EvmAddress } from "@/types/types";
 
 export default function User() {
-  const [vaultSelected, setVaultSelected] = useState("" as `0x${string}`);
+  const [vaultSelected, setVaultSelected] = useState("" as EvmAddress);
+  const [vaultAssetSelected, setVaultAssetSelected] = useState(
+    "" as EvmAddress,
+  );
+  console.log("L19 vaultAssetSelected ===", vaultAssetSelected);
+
+  const { deployedProxyHtsTokens } = useContext(Eip4626Context);
 
   const { deployedVaults } = useContext(Eip4626Context);
+  console.log("L31 deployedVaults ===", deployedVaults);
+
+  const vaultAddresses = deployedVaults.map((item) => item?.["args"]?.[0]);
+  console.log("L19 vaultAddresses extracted ===", vaultAddresses);
+
+  const vaultAssetsFetched = useReadHederaVaultAssetQueries(vaultAddresses);
+  console.log("L20 vaultAssetsFetched ===", vaultAssetsFetched);
+
+  const filteredVaultsBySelectedAsset = vaultAssetsFetched.filter(
+    (item) => item?.data?.vaultAssetAddress === vaultAssetSelected,
+  );
+
+  console.log(
+    "L31 filteredVaultsBySelectedAsset ===",
+    filteredVaultsBySelectedAsset,
+  );
+
+  const filteredVaultsForSelect = deployedVaults.filter((item) => {
+    return filteredVaultsBySelectedAsset.find(
+      (subItem) => subItem?.data?.vaultAddress === item?.["args"]?.[0],
+    );
+  });
+
+  console.log("L39 filteredVaultsForSelect ===", filteredVaultsForSelect);
 
   return (
     <>
-      <Stack spacing={4} align="center">
-        <Select
-          placeholder="Select vault for operation"
-          onChange={(item) => {
-            const vaultItem = deployedVaults.find(
-              (itemSub) => itemSub?.["args"]?.[0] === item.target.value,
-            );
-            setVaultSelected(vaultItem?.["args"]?.[0]);
-          }}
-          variant="outline"
-        >
-          {deployedVaults.map((item) => (
-            <option key={item?.["args"]?.[0]} value={item?.["args"]?.[0]}>
-              {item?.["args"]?.[1]} ({item?.["args"]?.[2]}) [
-              {item?.["args"]?.[0]}]
-            </option>
-          ))}
-        </Select>
+      {!deployedProxyHtsTokens.length ? (
+        <>No deployed HTS token addresses found</>
+      ) : (
+        <Stack spacing={4} align="center">
+          <Select
+            placeholder="Select vault asset for operation"
+            onChange={(item) => {
+              setVaultAssetSelected(item.target.value as EvmAddress);
+            }}
+            variant="outline"
+          >
+            {deployedProxyHtsTokens.map((item) => (
+              <option key={item} value={item}>
+                {item}
+              </option>
+            ))}
+          </Select>
+        </Stack>
+      )}
+
+      <Stack>
+        <MintAssetToken vaultAssetSelected={vaultAssetSelected} />
       </Stack>
+
+      {vaultAssetSelected && (
+        <Stack spacing={4} align="center">
+          <Select
+            placeholder="Select vault for operation"
+            onChange={(item) => {
+              const vaultItem = filteredVaultsForSelect.find(
+                (itemSub) => itemSub?.["args"]?.[0] === item.target.value,
+              );
+              setVaultSelected(vaultItem?.["args"]?.[0]);
+            }}
+            variant="outline"
+          >
+            {filteredVaultsForSelect.map((item) => (
+              <option key={item?.["args"]?.[0]} value={item?.["args"]?.[0]}>
+                {item?.["args"]?.[1]} ({item?.["args"]?.[2]}) [
+                {item?.["args"]?.[0]}]
+              </option>
+            ))}
+          </Select>
+        </Stack>
+      )}
+
       {vaultSelected && (
         <>
           <Divider my={10} />

--- a/src/components/eip4626/User.tsx
+++ b/src/components/eip4626/User.tsx
@@ -16,26 +16,15 @@ export default function User() {
   const [vaultAssetSelected, setVaultAssetSelected] = useState(
     "" as EvmAddress,
   );
-  console.log("L19 vaultAssetSelected ===", vaultAssetSelected);
 
   const { deployedProxyHtsTokens } = useContext(Eip4626Context);
-
   const { deployedVaults } = useContext(Eip4626Context);
-  console.log("L31 deployedVaults ===", deployedVaults);
 
   const vaultAddresses = deployedVaults.map((item) => item?.["args"]?.[0]);
-  console.log("L19 vaultAddresses extracted ===", vaultAddresses);
-
   const vaultAssetsFetched = useReadHederaVaultAssetQueries(vaultAddresses);
-  console.log("L20 vaultAssetsFetched ===", vaultAssetsFetched);
 
   const filteredVaultsBySelectedAsset = vaultAssetsFetched.filter(
     (item) => item?.data?.vaultAssetAddress === vaultAssetSelected,
-  );
-
-  console.log(
-    "L31 filteredVaultsBySelectedAsset ===",
-    filteredVaultsBySelectedAsset,
   );
 
   const filteredVaultsForSelect = deployedVaults.filter((item) => {
@@ -43,8 +32,6 @@ export default function User() {
       (subItem) => subItem?.data?.vaultAddress === item?.["args"]?.[0],
     );
   });
-
-  console.log("L39 filteredVaultsForSelect ===", filteredVaultsForSelect);
 
   return (
     <>

--- a/src/components/eip4626/User.tsx
+++ b/src/components/eip4626/User.tsx
@@ -1,5 +1,5 @@
 import { useState, useContext } from "react";
-import { Divider, Select, Stack } from "@chakra-ui/react";
+import { Divider, Select, Stack, Text } from "@chakra-ui/react";
 import { VaultWithdraw } from "@/components/eip4626/user/VaultWithdraw";
 import { VaultAssociate } from "@/components/eip4626/user/VaultAssociate";
 import { VaultClaimAllReward } from "@/components/eip4626/user/VaultClaimAllReward";
@@ -35,9 +35,7 @@ export default function User() {
 
   return (
     <>
-      {!deployedProxyHtsTokens.length ? (
-        <>No deployed HTS token addresses found</>
-      ) : (
+      {deployedProxyHtsTokens.length ? (
         <Stack spacing={4} align="center">
           <Select
             placeholder="Select vault asset for operation"
@@ -53,6 +51,8 @@ export default function User() {
             ))}
           </Select>
         </Stack>
+      ) : (
+        <Text>No deployed HTS token addresses found</Text>
       )}
 
       <Stack>

--- a/src/components/eip4626/User.tsx
+++ b/src/components/eip4626/User.tsx
@@ -1,5 +1,5 @@
 import { useState, useContext } from "react";
-import { Divider, Select, Stack, Text } from "@chakra-ui/react";
+import { Divider, Select, Stack, Text, VStack } from "@chakra-ui/react";
 import { VaultWithdraw } from "@/components/eip4626/user/VaultWithdraw";
 import { VaultAssociate } from "@/components/eip4626/user/VaultAssociate";
 import { VaultClaimAllReward } from "@/components/eip4626/user/VaultClaimAllReward";
@@ -55,9 +55,13 @@ export default function User() {
         <Text>No deployed HTS token addresses found</Text>
       )}
 
+      <Divider my={10} />
+
       <Stack>
         <MintAssetToken vaultAssetSelected={vaultAssetSelected} />
       </Stack>
+
+      <Divider my={10} />
 
       {vaultAssetSelected && (
         <Stack spacing={4} align="center">

--- a/src/components/eip4626/user/MintAssetToken.tsx
+++ b/src/components/eip4626/user/MintAssetToken.tsx
@@ -62,7 +62,7 @@ export function MintAssetToken({ vaultAssetSelected }: VaultMintTokenProps) {
     if (hasNextPage && !isFetching) {
       fetchNextPage();
     }
-  }, [accountTokens, fetchNextPage, hasNextPage, isFetching]);
+  }, [fetchNextPage, hasNextPage, isFetching]);
 
   const [tokenHasAssociation, setTokenHasAssociation] = useState(false);
   useEffect(() => {

--- a/src/components/eip4626/user/MintAssetToken.tsx
+++ b/src/components/eip4626/user/MintAssetToken.tsx
@@ -86,7 +86,6 @@ export function MintAssetToken({ vaultAssetSelected }: VaultMintTokenProps) {
       {deployedHtsTokensAddress && (
         <>
           <Text>HTS Token CA: {deployedHtsTokensAddress}</Text>
-          <Text>HTS Token Proxy CA: {vaultAssetSelected}</Text>
           <Text>
             User balance of token:{" "}
             {`${formatBalance(tokenBalance, vaultAssetSelectedDecimals)}`}
@@ -135,6 +134,7 @@ export function MintAssetToken({ vaultAssetSelected }: VaultMintTokenProps) {
           >
             Mint {DEFAULT_TOKEN_MINT_AMOUNT} tokens
           </Button>
+          <Text fontSize={12}>HTS Token Proxy CA: {vaultAssetSelected}</Text>
         </>
       )}
       {associateResult && (

--- a/src/components/eip4626/user/MintAssetToken.tsx
+++ b/src/components/eip4626/user/MintAssetToken.tsx
@@ -1,0 +1,76 @@
+import { useReadHtsTokenTokenAddress } from "@/hooks/eip4626/useReadHtsTokenTokenAddress";
+import { useWriteHtsTokenAssociate } from "@/hooks/eip4626/mutations/useWriteHtsTokenAssociate";
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Button,
+  Text,
+} from "@chakra-ui/react";
+import { VaultMintTokenProps } from "@/types/types";
+import { useWriteHtsTokenMint } from "@/hooks/eip4626/mutations/useWriteHtsTokenMint";
+
+export function MintAssetToken({ vaultAssetSelected }: VaultMintTokenProps) {
+  //@TODO add readTokenName to show vault asset token names
+  const { data: deployedHtsTokensAddress } =
+    useReadHtsTokenTokenAddress(vaultAssetSelected);
+  console.log("L11 deployedHtsTokensAddress ===", deployedHtsTokensAddress);
+
+  const {
+    data: associateResult,
+    mutateAsync: associate,
+    error: associateError,
+    isPending: isAssociatePending,
+  } = useWriteHtsTokenAssociate();
+
+  const {
+    data: mintResult,
+    mutateAsync: mint,
+    error: mintError,
+    isPending: isMintPending,
+  } = useWriteHtsTokenMint();
+
+  return (
+    <>
+      {deployedHtsTokensAddress && (
+        <>
+          <Text>HTS Token CA: {deployedHtsTokensAddress}</Text>
+          <Text>HTS Token Proxy CA: {vaultAssetSelected}</Text>
+          <Button
+            onClick={() =>
+              associate({
+                tokenAddress: vaultAssetSelected,
+              })
+            }
+          >
+            Associate
+          </Button>
+          <Button
+            onClick={() =>
+              mint({
+                tokenAddress: vaultAssetSelected,
+              })
+            }
+          >
+            Mint 1000 tokens
+          </Button>
+        </>
+      )}
+      {associateError && (
+        <Alert status="error">
+          <AlertIcon />
+          <AlertTitle>Associate token error!</AlertTitle>
+          <AlertDescription>{associateError.toString()}</AlertDescription>
+        </Alert>
+      )}
+      {mintError && (
+        <Alert status="error">
+          <AlertIcon />
+          <AlertTitle>Mint token error!</AlertTitle>
+          <AlertDescription>{mintError.toString()}</AlertDescription>
+        </Alert>
+      )}
+    </>
+  );
+}

--- a/src/components/eip4626/user/MintAssetToken.tsx
+++ b/src/components/eip4626/user/MintAssetToken.tsx
@@ -8,14 +8,13 @@ import {
   Button,
   Text,
 } from "@chakra-ui/react";
-import { VaultMintTokenProps } from "@/types/types";
+import { EvmAddress, VaultMintTokenProps } from "@/types/types";
 import { useWriteHtsTokenMint } from "@/hooks/eip4626/mutations/useWriteHtsTokenMint";
 
 export function MintAssetToken({ vaultAssetSelected }: VaultMintTokenProps) {
   //@TODO add readTokenName to show vault asset token names
   const { data: deployedHtsTokensAddress } =
     useReadHtsTokenTokenAddress(vaultAssetSelected);
-  console.log("L11 deployedHtsTokensAddress ===", deployedHtsTokensAddress);
 
   const {
     data: associateResult,
@@ -40,7 +39,8 @@ export function MintAssetToken({ vaultAssetSelected }: VaultMintTokenProps) {
           <Button
             onClick={() =>
               associate({
-                tokenAddress: vaultAssetSelected,
+                tokenAddress:
+                  deployedHtsTokensAddress?.toString() as EvmAddress,
               })
             }
           >

--- a/src/components/eip4626/user/MintAssetToken.tsx
+++ b/src/components/eip4626/user/MintAssetToken.tsx
@@ -14,7 +14,7 @@ import {
   useWriteHtsTokenMint,
 } from "@/hooks/eip4626/mutations/useWriteHtsTokenMint";
 import { useReadTokenDecimals } from "@/hooks/eip4626/useReadTokenDecimals";
-import { formatNumberToBigint } from "@/services/util/helpers";
+import { formatBalance, formatNumberToBigint } from "@/services/util/helpers";
 import { useReadBalanceOf } from "@/hooks/useReadBalanceOf";
 import { useAccountTokens } from "@/hooks/useAccountTokens";
 import { useEffect, useState } from "react";
@@ -51,8 +51,6 @@ export function MintAssetToken({ vaultAssetSelected }: VaultMintTokenProps) {
     deployedHtsTokensAddress as `0x${string}`,
   );
 
-  console.log("L60 tokenBalance ===", tokenBalance);
-
   const {
     data: accountTokens,
     isFetching,
@@ -88,6 +86,10 @@ export function MintAssetToken({ vaultAssetSelected }: VaultMintTokenProps) {
         <>
           <Text>HTS Token CA: {deployedHtsTokensAddress}</Text>
           <Text>HTS Token Proxy CA: {vaultAssetSelected}</Text>
+          <Text>
+            User balance of token:{" "}
+            {`${formatBalance(tokenBalance, vaultAssetSelectedDecimals)}`}
+          </Text>
           <Button
             isLoading={isAssociatePending}
             isDisabled={tokenHasAssociation}

--- a/src/components/eip4626/user/VaultWithdraw.tsx
+++ b/src/components/eip4626/user/VaultWithdraw.tsx
@@ -21,7 +21,6 @@ import { useReadBalanceOf } from "@/hooks/useReadBalanceOf";
 import { formatBalance, formatNumberToBigint } from "@/services/util/helpers";
 import { useWriteHederaVaultApprove } from "@/hooks/eip4626/mutations/useWriteHederaVaultApprove";
 import { useQueryClient } from "@tanstack/react-query";
-import { useReadHederaVaultPreviewWithdraw } from "@/hooks/eip4626/useReadHederaVaultPreviewWithdraw";
 import { useReadHederaVaultUserContribution } from "@/hooks/eip4626/useReadHederaVaultUserContribution";
 
 export function VaultWithdraw({ vaultAddress }: VaultInfoProps) {
@@ -74,10 +73,11 @@ export function VaultWithdraw({ vaultAddress }: VaultInfoProps) {
     });
   };
 
-  const { data: previewWithdrawData } = useReadHederaVaultPreviewWithdraw(
-    vaultAddress,
-    form.values.amount,
-  );
+  //@TODO call not working for small amounts with decimals
+  // const { data: previewWithdrawData } = useReadHederaVaultPreviewWithdraw(
+  //   vaultAddress,
+  //   form.values.amount,
+  // );
 
   const { data: userContribution } =
     useReadHederaVaultUserContribution(vaultAddress);
@@ -108,10 +108,10 @@ export function VaultWithdraw({ vaultAddress }: VaultInfoProps) {
               User balance of vault share token: {`${balanceFormatted}`}
             </FormHelperText>
 
-            <FormHelperText>
-              Amount of vault share token will be burned:{" "}
-              {previewWithdrawData?.toString()}
-            </FormHelperText>
+            {/*<FormHelperText>*/}
+            {/*  Amount of vault share token will be burned:{" "}*/}
+            {/*  {previewWithdrawData?.toString()}*/}
+            {/*</FormHelperText>*/}
 
             {shareUserBalanceError && (
               <FormHelperText color={"red"}>

--- a/src/contexts/Eip4626Context.tsx
+++ b/src/contexts/Eip4626Context.tsx
@@ -1,14 +1,19 @@
 import { LogDescription } from "ethers";
 import { createContext, ReactNode, useState } from "react";
+import { EvmAddress } from "@/types/types";
 
 type defaultContextType = {
   deployedVaults: LogDescription[];
+  deployedProxyHtsTokens: EvmAddress[];
   setDeployedVaults: (newValue: []) => void;
+  setDeployedProxyHtsTokens: (newValue: []) => void;
 };
 
 const defaultValue: defaultContextType = {
   deployedVaults: [],
+  deployedProxyHtsTokens: [],
   setDeployedVaults: (newValue) => {},
+  setDeployedProxyHtsTokens: (newValue) => {},
 };
 
 export const Eip4626Context = createContext(defaultValue);
@@ -20,11 +25,17 @@ export const Eip4626ContextProvider = (props: {
     defaultValue.deployedVaults,
   );
 
+  const [deployedProxyHtsTokens, setDeployedProxyHtsTokens] = useState(
+    defaultValue.deployedProxyHtsTokens,
+  );
+
   return (
     <Eip4626Context.Provider
       value={{
         deployedVaults,
         setDeployedVaults,
+        deployedProxyHtsTokens,
+        setDeployedProxyHtsTokens,
       }}
     >
       {props.children}

--- a/src/hooks/eip4626/mutations/useWriteHtsTokenAssociate.ts
+++ b/src/hooks/eip4626/mutations/useWriteHtsTokenAssociate.ts
@@ -1,0 +1,18 @@
+import { HtsTokenAssociateRequest } from "@/types/types";
+import { useMutation } from "@tanstack/react-query";
+import { writeHtsTokenAssociate } from "@/services/contracts/wagmiGenActions";
+import { WalletInterface } from "@/services/wallets/walletInterface";
+import { useWalletInterface } from "@/services/wallets/useWalletInterface";
+
+export function useWriteHtsTokenAssociate() {
+  const { walletInterface } = useWalletInterface();
+
+  return useMutation({
+    mutationFn: ({ tokenAddress }: HtsTokenAssociateRequest) =>
+      writeHtsTokenAssociate(
+        walletInterface as WalletInterface,
+        {},
+        tokenAddress,
+      ),
+  });
+}

--- a/src/hooks/eip4626/mutations/useWriteHtsTokenMint.ts
+++ b/src/hooks/eip4626/mutations/useWriteHtsTokenMint.ts
@@ -4,17 +4,17 @@ import { HtsTokenMintRequest } from "@/types/types";
 import { writeHtsTokenMint } from "@/services/contracts/wagmiGenActions";
 import { WalletInterface } from "@/services/wallets/walletInterface";
 
+export const DEFAULT_TOKEN_MINT_AMOUNT = 100;
+
 export function useWriteHtsTokenMint() {
   const { walletInterface } = useWalletInterface();
 
-  const DEFAULT_TOKEN_MINT_AMOUNT = BigInt(1000);
-
   return useMutation({
-    mutationFn: ({ tokenAddress }: HtsTokenMintRequest) => {
+    mutationFn: ({ tokenAddress, mintAmount }: HtsTokenMintRequest) => {
       return writeHtsTokenMint(
         walletInterface as WalletInterface,
         {
-          args: [DEFAULT_TOKEN_MINT_AMOUNT],
+          args: [mintAmount],
         },
         tokenAddress,
       );

--- a/src/hooks/eip4626/mutations/useWriteHtsTokenMint.ts
+++ b/src/hooks/eip4626/mutations/useWriteHtsTokenMint.ts
@@ -1,0 +1,23 @@
+import { useWalletInterface } from "@/services/wallets/useWalletInterface";
+import { useMutation } from "@tanstack/react-query";
+import { HtsTokenMintRequest } from "@/types/types";
+import { writeHtsTokenMint } from "@/services/contracts/wagmiGenActions";
+import { WalletInterface } from "@/services/wallets/walletInterface";
+
+export function useWriteHtsTokenMint() {
+  const { walletInterface } = useWalletInterface();
+
+  const DEFAULT_TOKEN_MINT_AMOUNT = BigInt(1000);
+
+  return useMutation({
+    mutationFn: ({ tokenAddress }: HtsTokenMintRequest) => {
+      return writeHtsTokenMint(
+        walletInterface as WalletInterface,
+        {
+          args: [DEFAULT_TOKEN_MINT_AMOUNT],
+        },
+        tokenAddress,
+      );
+    },
+  });
+}

--- a/src/hooks/eip4626/useReadHederaVaultAsset.ts
+++ b/src/hooks/eip4626/useReadHederaVaultAsset.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import { QueryKeysEIP4626 } from "@/hooks/types";
 import { readHederaVaultAsset } from "@/services/contracts/wagmiGenActions";
 import { EvmAddress } from "@/types/types";
@@ -7,5 +7,23 @@ export function useReadHederaVaultAsset(vaultAddress: EvmAddress) {
   return useQuery({
     queryKey: [QueryKeysEIP4626.ReadHederaVaultAsset, vaultAddress],
     queryFn: () => readHederaVaultAsset({}, vaultAddress),
+  });
+}
+
+export function useReadHederaVaultAssetQueries(vaultAddresses: EvmAddress[]) {
+  return useQueries({
+    queries: vaultAddresses.map((vaultAddress) => ({
+      queryKey: [QueryKeysEIP4626.ReadHederaVaultAssetQueries, vaultAddress],
+      queryFn: async () => {
+        let vaultAssetAddress = await readHederaVaultAsset({}, vaultAddress);
+        let result = {
+          vaultAssetAddress: vaultAssetAddress.toString(),
+          vaultAddress,
+        };
+        console.log("L21 useReadHederaVaultAssetQueries ===", result);
+        return result;
+      },
+      // staleTime: Infinity,
+    })),
   });
 }

--- a/src/hooks/eip4626/useReadHederaVaultAsset.ts
+++ b/src/hooks/eip4626/useReadHederaVaultAsset.ts
@@ -20,7 +20,6 @@ export function useReadHederaVaultAssetQueries(vaultAddresses: EvmAddress[]) {
           vaultAssetAddress: vaultAssetAddress.toString(),
           vaultAddress,
         };
-        console.log("L21 useReadHederaVaultAssetQueries ===", result);
         return result;
       },
       // staleTime: Infinity,

--- a/src/hooks/eip4626/useReadHederaVaultAsset.ts
+++ b/src/hooks/eip4626/useReadHederaVaultAsset.ts
@@ -22,7 +22,6 @@ export function useReadHederaVaultAssetQueries(vaultAddresses: EvmAddress[]) {
         };
         return result;
       },
-      // staleTime: Infinity,
     })),
   });
 }

--- a/src/hooks/eip4626/useReadHtsTokenTokenAddress.ts
+++ b/src/hooks/eip4626/useReadHtsTokenTokenAddress.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { QueryKeys } from "@/hooks/types";
+import { readHtsTokenTokenAddress } from "@/services/contracts/wagmiGenActions";
+import { EvmAddress } from "@/types/types";
+
+/**
+ * Considering that we use HTSToken CA as a wrapper to call "mint" of regular HTS token,
+ * we want to read the full non-zeroed EVM address of the underlying HTS token
+ * @param deployedProxyHtsToken
+ */
+export function useReadHtsTokenTokenAddress(deployedProxyHtsToken: EvmAddress) {
+  return useQuery({
+    queryKey: [QueryKeys.ReadHtsTokenTokenAddress, deployedProxyHtsToken],
+    queryFn: () => readHtsTokenTokenAddress({}, deployedProxyHtsToken),
+    enabled: !!deployedProxyHtsToken,
+  });
+}

--- a/src/hooks/eip4626/useReadHtsTokenTokenAddress.ts
+++ b/src/hooks/eip4626/useReadHtsTokenTokenAddress.ts
@@ -4,8 +4,9 @@ import { readHtsTokenTokenAddress } from "@/services/contracts/wagmiGenActions";
 import { EvmAddress } from "@/types/types";
 
 /**
- * Considering that we use HTSToken CA as a wrapper to call "mint" of regular HTS token,
- * we want to read the full non-zeroed EVM address of the underlying HTS token
+ * Considering that we use HTSToken CA as a proxy to allow users to associate/mint underlying HTS token,
+ * `tokenAddress` will return the EVM address of the said HTS token
+ *
  * @param deployedProxyHtsToken
  */
 export function useReadHtsTokenTokenAddress(deployedProxyHtsToken: EvmAddress) {

--- a/src/hooks/eip4626/useReadHtsTokenTokenAddress.ts
+++ b/src/hooks/eip4626/useReadHtsTokenTokenAddress.ts
@@ -14,5 +14,6 @@ export function useReadHtsTokenTokenAddress(deployedProxyHtsToken: EvmAddress) {
     queryKey: [QueryKeys.ReadHtsTokenTokenAddress, deployedProxyHtsToken],
     queryFn: () => readHtsTokenTokenAddress({}, deployedProxyHtsToken),
     enabled: !!deployedProxyHtsToken,
+    select: (data) => data?.toString() as EvmAddress,
   });
 }

--- a/src/hooks/eip4626/useReadTokenDecimals.ts
+++ b/src/hooks/eip4626/useReadTokenDecimals.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { readTokenDecimals } from "@/services/contracts/wagmiGenActions";
+import { EvmAddress } from "@/types/types";
+
+export function useReadTokenDecimals(tokenAddress?: EvmAddress) {
+  return useQuery({
+    queryKey: [],
+    queryFn: () => readTokenDecimals({}, tokenAddress),
+    enabled: !!tokenAddress,
+    select: (data) => Number(data),
+  });
+}

--- a/src/hooks/mutations/useCreateIdentityFactory.ts
+++ b/src/hooks/mutations/useCreateIdentityFactory.ts
@@ -15,8 +15,5 @@ export function useCreateIdentityFactory() {
           args: [address],
         },
       ),
-    onSuccess: (data, variables, context) => {
-      console.log("useCreateIdentityFactory onSuccess", data);
-    },
   });
 }

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -5,6 +5,7 @@ export enum QueryKeys {
   ReadBalanceOf = "readBalanceOf",
   ReadTokenCompliance = "readTokenCompliance",
   ReadModularComplianceGetModules = "readModularComplianceGetModules",
+  ReadHtsTokenTokenAddress = "readHtsTokenTokenAddress",
 }
 
 export enum QueryKeysEIP4626 {
@@ -20,4 +21,5 @@ export enum QueryKeysEIP4626 {
   ReadHederaVaultPreviewWithdraw = "readHederaVaultPreviewWithdraw",
   ReadHederaVaultGetUserReward = "readHederaVaultGetUserReward",
   ReadHederaVaultUserContribution = "readHederaVaultUserContribution",
+  ReadHederaVaultAssetQueries = "readHederaVaultAssetQueries",
 }

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -6,6 +6,7 @@ export enum QueryKeys {
   ReadTokenCompliance = "readTokenCompliance",
   ReadModularComplianceGetModules = "readModularComplianceGetModules",
   ReadHtsTokenTokenAddress = "readHtsTokenTokenAddress",
+  ReadAccountTokens = "readAccountTokens",
 }
 
 export enum QueryKeysEIP4626 {

--- a/src/hooks/useAccountTokens.ts
+++ b/src/hooks/useAccountTokens.ts
@@ -12,7 +12,13 @@ export function useAccountTokens() {
     initialPageParam: "",
     refetchOnWindowFocus: false,
     enabled: !!accountEvm,
-    select: (data) => data.pages.flatMap((x) => x.tokens),
+    select: (data) => {
+      if (data && data.pages) {
+        return data.pages.flatMap((x) => x.tokens);
+      } else {
+        return [];
+      }
+    },
     getNextPageParam: (lastPage, allPages, lastPageParam) => {
       if (lastPage?.links?.next) {
         return lastPage?.links?.next;

--- a/src/hooks/useAccountTokens.ts
+++ b/src/hooks/useAccountTokens.ts
@@ -21,7 +21,7 @@ export function useAccountTokens() {
     },
     getNextPageParam: (lastPage, allPages, lastPageParam) => {
       if (lastPage?.links?.next) {
-        return lastPage?.links?.next;
+        return lastPage.links.next;
       } else {
         return undefined;
       }

--- a/src/hooks/useAccountTokens.ts
+++ b/src/hooks/useAccountTokens.ts
@@ -6,7 +6,6 @@ import { fetchAccountTokens } from "@/services/api/requests";
 export function useAccountTokens() {
   const { accountEvm } = useWalletInterface();
 
-  //@TODO convert token_id to evm address after fetching it
   return useInfiniteQuery({
     queryKey: [QueryKeys.ReadAccountTokens, accountEvm],
     queryFn: ({ pageParam }) => fetchAccountTokens(accountEvm, pageParam),

--- a/src/hooks/useAccountTokens.ts
+++ b/src/hooks/useAccountTokens.ts
@@ -1,0 +1,25 @@
+import { useWalletInterface } from "@/services/wallets/useWalletInterface";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { QueryKeys } from "@/hooks/types";
+import { fetchAccountTokens } from "@/services/api/requests";
+
+export function useAccountTokens() {
+  const { accountEvm } = useWalletInterface();
+
+  //@TODO convert token_id to evm address after fetching it
+  return useInfiniteQuery({
+    queryKey: [QueryKeys.ReadAccountTokens, accountEvm],
+    queryFn: ({ pageParam }) => fetchAccountTokens(accountEvm, pageParam),
+    initialPageParam: "",
+    refetchOnWindowFocus: false,
+    enabled: !!accountEvm,
+    select: (data) => data.pages.flatMap((x) => x.tokens),
+    getNextPageParam: (lastPage, allPages, lastPageParam) => {
+      if (lastPage?.links?.next) {
+        return lastPage?.links?.next;
+      } else {
+        return undefined;
+      }
+    },
+  });
+}

--- a/src/services/api/requests.ts
+++ b/src/services/api/requests.ts
@@ -31,6 +31,22 @@ interface MirrorNodeTransaction {
   token_transfers: MirrorNodeTokenTransfer[];
 }
 
+interface MirrorNodeAccountToken {
+  automatic_association: boolean;
+  balance: number;
+  created_timestamp: string;
+  decimals: number;
+  freeze_status: string;
+  kyc_status: string;
+  token_id: string;
+}
+interface MirrorNodeAccountTokens {
+  links: {
+    next: string;
+  };
+  tokens: MirrorNodeAccountToken[];
+}
+
 /**
  * Fetches transaction details / records on Hedera network for a given TransactionId
  * @param transactionId - The ID of the transactions.
@@ -76,3 +92,16 @@ export async function convertAccountIdToEVMWallet(accountId: AccountId) {
   }
   return responseJson?._status || responseJson.evm_address;
 }
+
+export const fetchAccountTokens = async (
+  accountId: string | undefined,
+  pageParam: string,
+): Promise<MirrorNodeAccountTokens> => {
+  // if (!accountId) return [];
+
+  const { data: tokens } = await testnetMirrorNodeAPI.get(
+    pageParam ? pageParam : `/api/v1/accounts/${accountId}/tokens`,
+  );
+
+  return tokens;
+};

--- a/src/services/api/requests.ts
+++ b/src/services/api/requests.ts
@@ -97,8 +97,6 @@ export const fetchAccountTokens = async (
   accountId: string | undefined,
   pageParam: string,
 ): Promise<MirrorNodeAccountTokens> => {
-  // if (!accountId) return [];
-
   const { data: tokens } = await testnetMirrorNodeAPI.get(
     pageParam ? pageParam : `/api/v1/accounts/${accountId}/tokens`,
   );

--- a/src/services/api/requests.ts
+++ b/src/services/api/requests.ts
@@ -94,8 +94,8 @@ export async function convertAccountIdToEVMWallet(accountId: AccountId) {
 }
 
 export const fetchAccountTokens = async (
-  accountId: string | undefined,
-  pageParam: string,
+  accountId?: string,
+  pageParam?: string,
 ): Promise<MirrorNodeAccountTokens> => {
   const { data: tokens } = await testnetMirrorNodeAPI.get(
     pageParam ? pageParam : `/api/v1/accounts/${accountId}/tokens`,

--- a/src/services/contracts/readContract.ts
+++ b/src/services/contracts/readContract.ts
@@ -40,6 +40,8 @@ export async function readContract<
   parameters: ReadContractParameters<abi, functionName, args>,
 ): Promise<ReadContractReturnType<abi, functionName, args>> {
   const contractInterface = new ethers.Interface(parameters.abi as []);
+
+  //@TODO throw an error properly when no data can be encoded
   const data = contractInterface.encodeFunctionData(
     parameters.functionName,
     parameters.args as [],

--- a/src/services/contracts/wagmiGenActions.ts
+++ b/src/services/contracts/wagmiGenActions.ts
@@ -614,7 +614,7 @@ export const htsTokenAbi = [
 ] as const;
 
 export const htsTokenAddress =
-  "0x64984581817E03b85b3E9A6B49F488527345ea96" as const;
+  "0xDCf36eAd241EB927E1046abcF17fE9FB31ecc646" as const;
 
 export const htsTokenConfig = {
   address: htsTokenAddress,
@@ -665,7 +665,7 @@ export const htsTokenFactoryAbi = [
 ] as const;
 
 export const htsTokenFactoryAddress =
-  "0x54F4C057712680693d550b8e691b8a5948d69390" as const;
+  "0x1Ed9b9832A84E312d1B2670A3a9b853FAd499189" as const;
 
 export const htsTokenFactoryConfig = {
   address: htsTokenFactoryAddress,

--- a/src/services/contracts/wagmiGenActions.ts
+++ b/src/services/contracts/wagmiGenActions.ts
@@ -519,6 +519,109 @@ export const erc20Address =
 export const erc20Config = { address: erc20Address, abi: erc20Abi } as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// HTSToken
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const htsTokenAbi = [
+  {
+    type: "constructor",
+    inputs: [
+      { name: "tokenName", internalType: "string", type: "string" },
+      { name: "tokenSymbol", internalType: "string", type: "string" },
+      { name: "decimals", internalType: "int32", type: "int32" },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "tokenAddress",
+        internalType: "address",
+        type: "address",
+        indexed: false,
+      },
+      {
+        name: "userAddress",
+        internalType: "address",
+        type: "address",
+        indexed: false,
+      },
+    ],
+    name: "AssociatedToken",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "tokenAddress",
+        internalType: "address",
+        type: "address",
+        indexed: false,
+      },
+    ],
+    name: "CreatedToken",
+  },
+  {
+    type: "event",
+    anonymous: false,
+    inputs: [
+      {
+        name: "tokenAddress",
+        internalType: "address",
+        type: "address",
+        indexed: false,
+      },
+      { name: "amount", internalType: "int64", type: "int64", indexed: false },
+      {
+        name: "newTotalSupply",
+        internalType: "int64",
+        type: "int64",
+        indexed: false,
+      },
+    ],
+    name: "MintedToken",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "associate",
+    outputs: [
+      { name: "responseCode", internalType: "uint256", type: "uint256" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [{ name: "amount", internalType: "int64", type: "int64" }],
+    name: "mint",
+    outputs: [
+      { name: "responseCode", internalType: "int256", type: "int256" },
+      { name: "newTotalSupply", internalType: "int64", type: "int64" },
+      { name: "serialNumbers", internalType: "int64[]", type: "int64[]" },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    inputs: [],
+    name: "tokenAddress",
+    outputs: [{ name: "", internalType: "address", type: "address" }],
+    stateMutability: "view",
+  },
+] as const;
+
+export const htsTokenAddress =
+  "0xA5c414Cc5004B4e84Be5A156c4D343CBF6a1b2E1" as const;
+
+export const htsTokenConfig = {
+  address: htsTokenAddress,
+  abi: htsTokenAbi,
+} as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // HTSTokenFactory
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -562,7 +665,7 @@ export const htsTokenFactoryAbi = [
 ] as const;
 
 export const htsTokenFactoryAddress =
-  "0x7ae9b7b41A17F586B12226B3a50bF98Ecf641B5b" as const;
+  "0x92eC9DDB4da01d421c2650E41dcAFdA7DD49a4a8" as const;
 
 export const htsTokenFactoryConfig = {
   address: htsTokenFactoryAddress,
@@ -7290,6 +7393,113 @@ export const watchErc20TransferEvent = /*#__PURE__*/ createWatchContractEvent({
   address: erc20Address,
   eventName: "Transfer",
 });
+
+/**
+ * Wraps __{@link readContract}__ with `abi` set to __{@link htsTokenAbi}__
+ */
+export const readHtsToken = /*#__PURE__*/ createReadContract({
+  abi: htsTokenAbi,
+  address: htsTokenAddress,
+});
+
+/**
+ * Wraps __{@link readContract}__ with `abi` set to __{@link htsTokenAbi}__ and `functionName` set to `"tokenAddress"`
+ */
+export const readHtsTokenTokenAddress = /*#__PURE__*/ createReadContract({
+  abi: htsTokenAbi,
+  address: htsTokenAddress,
+  functionName: "tokenAddress",
+});
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link htsTokenAbi}__
+ */
+export const writeHtsToken = /*#__PURE__*/ createWriteContract({
+  abi: htsTokenAbi,
+  address: htsTokenAddress,
+});
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link htsTokenAbi}__ and `functionName` set to `"associate"`
+ */
+export const writeHtsTokenAssociate = /*#__PURE__*/ createWriteContract({
+  abi: htsTokenAbi,
+  address: htsTokenAddress,
+  functionName: "associate",
+});
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link htsTokenAbi}__ and `functionName` set to `"mint"`
+ */
+export const writeHtsTokenMint = /*#__PURE__*/ createWriteContract({
+  abi: htsTokenAbi,
+  address: htsTokenAddress,
+  functionName: "mint",
+});
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link htsTokenAbi}__
+ */
+export const simulateHtsToken = /*#__PURE__*/ createSimulateContract({
+  abi: htsTokenAbi,
+  address: htsTokenAddress,
+});
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link htsTokenAbi}__ and `functionName` set to `"associate"`
+ */
+export const simulateHtsTokenAssociate = /*#__PURE__*/ createSimulateContract({
+  abi: htsTokenAbi,
+  address: htsTokenAddress,
+  functionName: "associate",
+});
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link htsTokenAbi}__ and `functionName` set to `"mint"`
+ */
+export const simulateHtsTokenMint = /*#__PURE__*/ createSimulateContract({
+  abi: htsTokenAbi,
+  address: htsTokenAddress,
+  functionName: "mint",
+});
+
+/**
+ * Wraps __{@link watchContractEvent}__ with `abi` set to __{@link htsTokenAbi}__
+ */
+export const watchHtsTokenEvent = /*#__PURE__*/ createWatchContractEvent({
+  abi: htsTokenAbi,
+  address: htsTokenAddress,
+});
+
+/**
+ * Wraps __{@link watchContractEvent}__ with `abi` set to __{@link htsTokenAbi}__ and `eventName` set to `"AssociatedToken"`
+ */
+export const watchHtsTokenAssociatedTokenEvent =
+  /*#__PURE__*/ createWatchContractEvent({
+    abi: htsTokenAbi,
+    address: htsTokenAddress,
+    eventName: "AssociatedToken",
+  });
+
+/**
+ * Wraps __{@link watchContractEvent}__ with `abi` set to __{@link htsTokenAbi}__ and `eventName` set to `"CreatedToken"`
+ */
+export const watchHtsTokenCreatedTokenEvent =
+  /*#__PURE__*/ createWatchContractEvent({
+    abi: htsTokenAbi,
+    address: htsTokenAddress,
+    eventName: "CreatedToken",
+  });
+
+/**
+ * Wraps __{@link watchContractEvent}__ with `abi` set to __{@link htsTokenAbi}__ and `eventName` set to `"MintedToken"`
+ */
+export const watchHtsTokenMintedTokenEvent =
+  /*#__PURE__*/ createWatchContractEvent({
+    abi: htsTokenAbi,
+    address: htsTokenAddress,
+    eventName: "MintedToken",
+  });
 
 /**
  * Wraps __{@link readContract}__ with `abi` set to __{@link htsTokenFactoryAbi}__

--- a/src/services/contracts/wagmiGenActions.ts
+++ b/src/services/contracts/wagmiGenActions.ts
@@ -614,7 +614,7 @@ export const htsTokenAbi = [
 ] as const;
 
 export const htsTokenAddress =
-  "0xA5c414Cc5004B4e84Be5A156c4D343CBF6a1b2E1" as const;
+  "0x64984581817E03b85b3E9A6B49F488527345ea96" as const;
 
 export const htsTokenConfig = {
   address: htsTokenAddress,
@@ -665,7 +665,7 @@ export const htsTokenFactoryAbi = [
 ] as const;
 
 export const htsTokenFactoryAddress =
-  "0x76f8470F2973e2FB0295AF85cfA7B1B52F732C6C" as const;
+  "0x54F4C057712680693d550b8e691b8a5948d69390" as const;
 
 export const htsTokenFactoryConfig = {
   address: htsTokenFactoryAddress,

--- a/src/services/contracts/wagmiGenActions.ts
+++ b/src/services/contracts/wagmiGenActions.ts
@@ -665,7 +665,7 @@ export const htsTokenFactoryAbi = [
 ] as const;
 
 export const htsTokenFactoryAddress =
-  "0x92eC9DDB4da01d421c2650E41dcAFdA7DD49a4a8" as const;
+  "0x76f8470F2973e2FB0295AF85cfA7B1B52F732C6C" as const;
 
 export const htsTokenFactoryConfig = {
   address: htsTokenFactoryAddress,

--- a/src/services/util/helpers.tsx
+++ b/src/services/util/helpers.tsx
@@ -31,9 +31,7 @@ export function formatBalance(
   precision = VAULT_TOKEN_PRECISION_VALUE,
 ) {
   return !isNil(initialValue)
-    ? BigNumber(initialValue)
-        .shiftedBy(-precision)
-        .toFixed(VAULT_TOKEN_PRECISION_VALUE)
+    ? BigNumber(initialValue).shiftedBy(-precision).toFixed(precision)
     : 0;
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -80,6 +80,7 @@ export type HtsTokenAssociateRequest = {
 
 export type HtsTokenMintRequest = {
   tokenAddress: EvmAddress;
+  mintAmount: bigint;
 };
 
 export type VaultMintTokenProps = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -73,3 +73,15 @@ export type VaultWithdrawRequest = {
   vaultAddress: `0x${string}`;
   tokenAmount: bigint;
 };
+
+export type HtsTokenAssociateRequest = {
+  tokenAddress: EvmAddress;
+};
+
+export type HtsTokenMintRequest = {
+  tokenAddress: EvmAddress;
+};
+
+export type VaultMintTokenProps = {
+  vaultAssetSelected: EvmAddress;
+};

--- a/src/views/eip4626/EIP4626.tsx
+++ b/src/views/eip4626/EIP4626.tsx
@@ -6,11 +6,15 @@ import NoWalletConnected from "@/components/NoWalletConnected";
 import { WatchContractEventReturnType } from "@/services/contracts/watchContractEvent";
 import { useContext, useEffect } from "react";
 import { Eip4626Context } from "@/contexts/Eip4626Context";
-import { watchVaultFactoryVaultDeployedEvent } from "../../services/contracts/wagmiGenActions";
+import {
+  watchHtsTokenFactoryTokenDeployedEvent,
+  watchVaultFactoryVaultDeployedEvent,
+} from "@/services/contracts/wagmiGenActions";
 
 export default function EIP4626() {
   const { accountId } = useWalletInterface();
-  const { setDeployedVaults } = useContext(Eip4626Context);
+  const { setDeployedVaults, setDeployedProxyHtsTokens } =
+    useContext(Eip4626Context);
 
   useEffect(() => {
     const unsub: WatchContractEventReturnType =
@@ -25,6 +29,25 @@ export default function EIP4626() {
       unsub();
     };
   }, [setDeployedVaults]);
+
+  useEffect(() => {
+    const unsub: WatchContractEventReturnType =
+      watchHtsTokenFactoryTokenDeployedEvent({
+        onLogs: (data) => {
+          setDeployedProxyHtsTokens(((prev: any) => {
+            return [
+              ...prev,
+              ...data
+                .map((item: any) => item.args[0])
+                .filter((item) => !prev.includes(item)),
+            ];
+          }) as any);
+        },
+      });
+    return () => {
+      unsub();
+    };
+  }, [setDeployedProxyHtsTokens]);
 
   if (!accountId) return <NoWalletConnected />;
 

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -28,7 +28,7 @@ const ignore = env.SYNC_CONTRACTS_IGNORE.split(";");
 const contracts: Contracts = [
   {
     name: "ERC20",
-    address: "0x0000000000000000000000000000000000387719", // Dummy address, will be overriden on every call
+    address: "0x0000000000000000000000000000000000387719", // Dummy address, will be overridden on every call
     url: `https://raw.githubusercontent.com/web3-nomad/accelerator-defi-EIP/main/data/abis/ERC20.json`,
   },
 ];
@@ -56,10 +56,14 @@ export default defineConfig({
       })),
       async parse({ response }) {
         try {
+          if (response.status === 404)
+            throw new Error("Contract abi .json file fetch failed - Not Found");
+
           const json = await response.json();
           if (json.status === "0") throw new Error(JSON.stringify(response));
           return json.abi;
         } catch (e) {
+          console.error(e);
           throw new Error(JSON.stringify(e));
         }
       },

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -29,7 +29,7 @@ const contracts: Contracts = [
   {
     name: "ERC20",
     address: "0x0000000000000000000000000000000000387719", // Dummy address, will be overridden on every call
-    url: `https://raw.githubusercontent.com/web3-nomad/accelerator-defi-EIP/main/data/abis/ERC20.json`,
+    url: `https://raw.githubusercontent.com/hashgraph/hedera-accelerator-defi-eip/main/data/abis/ERC20.json`,
   },
 ];
 


### PR DESCRIPTION
This PR brings several changes:
- switching to the org urls for fetching latest abis
- generated new abis for `HTSToken` proxy and `HTSTokenFactory`
- adding listener for the deployments of the `HTSToken` proxies from `HTSTokenFactory`
- reading underlying `tokenAddress` from the deployed `HTSToken` proxy
- filtering the vaults by the selected vault asset
- ability for the user to call `associate` and `mint` for the vault asset via `HTSToken` proxy
- check if user has already associated the selected vault asset and disable respective `associate` button if thats the case

- [x] currently `mint` call fails as the `HTSToken` proxy needs KYC settings reconfigured. I will update the PR after respective changes are redeployed. - resolved by https://github.com/hashgraph/hedera-accelerator-defi-eip/pull/24