### PR TITLE
Loading token data optimisations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@netlify/plugin-nextjs": "^4.41.3",
         "@reduxjs/toolkit": "^2.2.1",
         "@tanstack/react-query": "^5.28.9",
+        "@uidotdev/usehooks": "^2.4.1",
         "@web3modal/ethers": "^4.1.5",
         "@web3modal/wagmi": "^4.0.13",
         "abitype": "^1.0.2",
@@ -30,6 +31,7 @@
         "react-dom": "^18",
         "react-redux": "^9.1.0",
         "react-router-dom": "^6.23.0",
+        "react-select": "^5.8.0",
         "react-use": "^17.5.1",
         "viem": "^2.7.22",
         "wagmi": "^2.5.7",
@@ -4526,6 +4528,28 @@
         "node": ">=14"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
+      "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.2.tgz",
@@ -8526,6 +8550,14 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
+      "integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
@@ -8703,6 +8735,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -13085,6 +13129,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dot-case": {
@@ -20371,6 +20424,31 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-select": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.1.tgz",
+      "integrity": "sha512-RT1CJmuc+ejqm5MPgzyZujqDskdvB9a9ZqrdnVLsvAHjJ3Tj0hELnLeVPQlmYdVKCdCpxanepl6z7R5KhXhWzg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-select/node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
     "node_modules/react-shallow-renderer": {
       "version": "16.15.0",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
@@ -20410,6 +20488,21 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
     },
     "node_modules/react-universal-interface": {
       "version": "0.6.2",
@@ -22748,6 +22841,19 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/use-sidecar": {
       "version": "1.1.2",

--- a/src/components/eip3643/Admin.tsx
+++ b/src/components/eip3643/Admin.tsx
@@ -6,43 +6,57 @@ import DeployToken from "@/components/eip3643/admin/DeployToken";
 import RegisterIdentity from "@/components/eip3643/admin/RegisterIdentity";
 import CreateIdentityFactory from "@/components/eip3643/admin/CreateIdentityFactory";
 import { Eip3643Context } from "@/contexts/Eip3643Context";
-import {
-  readTokenName,
-  readTokenOwner,
-} from "@/services/contracts/wagmiGenActions";
-import { TokenNameItem } from "@/types/types";
+import { TokenNameItem, TokenOwnerItem } from "@/types/types";
 import { useWalletInterface } from "@/services/wallets/useWalletInterface";
 import TokenInfo from "@/components/eip3643/admin/TokenInfo";
 import Compliance from "@/components/eip3643/admin/Compliance";
 import { MenuSelect } from "@/components/MenuSelect";
+import { useReadTokenOwnerQueries } from "@/hooks/useReadTokenOwnerQueries";
+import { useReadTokenNameQueries } from "@/hooks/useReadTokenNameQueries";
 
 export default function Admin() {
   const [isDeploy, setIsDeploy] = useState(false);
   const [tokenSelected, setTokenSelected] = useState<TokenNameItem>();
-  const [ownTokens, setOwnTokens] = useState([] as Array<TokenNameItem>);
+  const [ownTokens, setOwnTokens] = useState<TokenNameItem[]>([]);
   const { accountEvm } = useWalletInterface();
   const { deployedTokens } = useContext(Eip3643Context);
 
+  const { data: tokensWithOwners, isSuccess: tokensWithOwnersSuccess } =
+    useReadTokenOwnerQueries(deployedTokens);
+
+  const [userOwnedTokens, setUserOwnedTokens] = useState<TokenOwnerItem[]>([]);
+
   useEffect(() => {
-    (deployedTokens as any).map((item: any) => {
-      const tokenAddress = item["args"]?.[0];
-      tokenAddress &&
-        readTokenOwner({}, tokenAddress).then((resOwner) => {
-          resOwner[0].toString().toLowerCase() === accountEvm?.toLowerCase() &&
-            readTokenName({}, tokenAddress).then((resName) => {
-              setOwnTokens((prev) => {
-                return [
-                  ...prev.filter((itemSub) => itemSub.address !== tokenAddress),
-                  {
-                    address: tokenAddress,
-                    name: resName[0],
-                  },
-                ];
-              });
-            });
-        });
-    });
-  }, [deployedTokens, accountEvm, setOwnTokens]);
+    if (tokensWithOwnersSuccess) {
+      setUserOwnedTokens(
+        tokensWithOwners
+          .filter(
+            (tokenOwnerItem): tokenOwnerItem is TokenOwnerItem =>
+              tokenOwnerItem !== undefined,
+          )
+          .filter(
+            (tokenOwnerItem) =>
+              tokenOwnerItem.ownerAddress?.toLowerCase() ===
+              accountEvm?.toLowerCase(),
+          ),
+      );
+    }
+  }, [accountEvm, tokensWithOwners, tokensWithOwnersSuccess]);
+
+  const { data: userOwnedTokensWithNames, isSuccess: tokensWithNamesSuccess } =
+    useReadTokenNameQueries(
+      userOwnedTokens.map((userOwnedToken) => userOwnedToken.tokenAddress),
+    );
+
+  useEffect(() => {
+    if (tokensWithNamesSuccess) {
+      setOwnTokens(
+        userOwnedTokensWithNames.filter(
+          (token): token is TokenNameItem => token !== undefined,
+        ),
+      );
+    }
+  }, [tokensWithNamesSuccess, userOwnedTokensWithNames]);
 
   const handleTokenSelect = (value: string | number) => {
     const tokenItem = ownTokens.find((itemSub) => itemSub.address === value);

--- a/src/components/eip3643/Admin.tsx
+++ b/src/components/eip3643/Admin.tsx
@@ -5,58 +5,16 @@ import { GroupBase } from "react-select";
 import DeployToken from "@/components/eip3643/admin/DeployToken";
 import RegisterIdentity from "@/components/eip3643/admin/RegisterIdentity";
 import CreateIdentityFactory from "@/components/eip3643/admin/CreateIdentityFactory";
-import { Eip3643Context } from "@/contexts/Eip3643Context";
-import { TokenNameItem, TokenOwnerItem } from "@/types/types";
-import { useWalletInterface } from "@/services/wallets/useWalletInterface";
+import { TokenNameItem } from "@/types/types";
 import TokenInfo from "@/components/eip3643/admin/TokenInfo";
 import Compliance from "@/components/eip3643/admin/Compliance";
 import { MenuSelect } from "@/components/MenuSelect";
-import { useReadTokenOwnerQueries } from "@/hooks/useReadTokenOwnerQueries";
-import { useReadTokenNameQueries } from "@/hooks/useReadTokenNameQueries";
+import { useOwnTokens } from "@/hooks/eip3643/useOwnTokens";
 
 export default function Admin() {
   const [isDeploy, setIsDeploy] = useState(false);
   const [tokenSelected, setTokenSelected] = useState<TokenNameItem>();
-  const [ownTokens, setOwnTokens] = useState<TokenNameItem[]>([]);
-  const { accountEvm } = useWalletInterface();
-  const { deployedTokens } = useContext(Eip3643Context);
-
-  const { data: tokensWithOwners, isSuccess: tokensWithOwnersSuccess } =
-    useReadTokenOwnerQueries(deployedTokens);
-
-  const [userOwnedTokens, setUserOwnedTokens] = useState<TokenOwnerItem[]>([]);
-
-  useEffect(() => {
-    if (tokensWithOwnersSuccess) {
-      setUserOwnedTokens(
-        tokensWithOwners
-          .filter(
-            (tokenOwnerItem): tokenOwnerItem is TokenOwnerItem =>
-              tokenOwnerItem !== undefined,
-          )
-          .filter(
-            (tokenOwnerItem) =>
-              tokenOwnerItem.ownerAddress?.toLowerCase() ===
-              accountEvm?.toLowerCase(),
-          ),
-      );
-    }
-  }, [accountEvm, tokensWithOwners, tokensWithOwnersSuccess]);
-
-  const { data: userOwnedTokensWithNames, isSuccess: tokensWithNamesSuccess } =
-    useReadTokenNameQueries(
-      userOwnedTokens.map((userOwnedToken) => userOwnedToken.tokenAddress),
-    );
-
-  useEffect(() => {
-    if (tokensWithNamesSuccess) {
-      setOwnTokens(
-        userOwnedTokensWithNames.filter(
-          (token): token is TokenNameItem => token !== undefined,
-        ),
-      );
-    }
-  }, [tokensWithNamesSuccess, userOwnedTokensWithNames]);
+  const { ownTokens } = useOwnTokens();
 
   const handleTokenSelect = (value: string | number) => {
     const tokenItem = ownTokens.find((itemSub) => itemSub.address === value);

--- a/src/components/eip3643/User.tsx
+++ b/src/components/eip3643/User.tsx
@@ -9,7 +9,7 @@ import { MenuSelect } from "@/components/MenuSelect";
 import { GroupBase } from "react-select";
 import RegisterIdentity from "@/components/eip3643/admin/RegisterIdentity";
 import CreateIdentityFactory from "@/components/eip3643/admin/CreateIdentityFactory";
-import { useReadTokenName } from "@/hooks/useReadTokenName";
+import { useReadTokenNameQueries } from "@/hooks/useReadTokenNameQueries";
 import { useReadTokenIdentityRegistryQueries } from "@/hooks/useReadTokenIdentityRegistryQueries";
 
 export default function User() {
@@ -17,7 +17,7 @@ export default function User() {
   const { accountEvm } = useWalletInterface();
   const { deployedTokens } = useContext(Eip3643Context);
   const { data: tokens, isSuccess: tokensIsSuccess } =
-    useReadTokenName(deployedTokens);
+    useReadTokenNameQueries(deployedTokens);
 
   const [tokensByOwnership, setTokensByOwnership] = useState<TokenNameItem[]>(
     [],
@@ -49,9 +49,13 @@ export default function User() {
   useEffect(() => {
     if (!isReadyToLoadAgents) return;
 
+    const tokensFiltered = tokens.filter(
+      (token): token is TokenNameItem => token !== undefined,
+    );
+
     if (registriesAgents && accountEvm) {
       setTokensByOwnership(
-        tokens.toSorted((a) => {
+        tokensFiltered.toSorted((a) => {
           const tokenIncludesIdentity =
             registriesAgents[a.address]?.includes(accountEvm);
 
@@ -62,13 +66,15 @@ export default function User() {
           return 1;
         }),
       );
-    } else if (tokens) {
-      setTokensByOwnership(tokens);
+    } else {
+      setTokensByOwnership(tokensFiltered);
     }
   }, [registriesAgents, accountEvm, tokens, isReadyToLoadAgents]);
 
   const handleTokenSelect = (value: string) => {
-    const tokenItem = tokens.find((itemSub) => itemSub.address === value);
+    const tokenItem = tokens
+      .filter((token): token is TokenNameItem => token !== undefined)
+      .find((itemSub) => itemSub.address === value);
     setTokenSelected(tokenItem);
   };
 

--- a/src/components/eip3643/User.tsx
+++ b/src/components/eip3643/User.tsx
@@ -1,52 +1,59 @@
-import { useEffect, useContext, useState } from "react";
+import { useEffect, useContext, useState, useMemo } from "react";
 import TransferToken from "@/components/eip3643/user/TransferToken";
 import { Eip3643Context } from "@/contexts/Eip3643Context";
-import { readTokenName } from "@/services/contracts/wagmiGenActions";
 import { TokenNameItem } from "@/types/types";
 import { useWalletInterface } from "@/services/wallets/useWalletInterface";
 import { Divider, Stack, Text, Box } from "@chakra-ui/react";
 import { useTokensIdentityRegistries } from "@/hooks/useTokensIdentityRegistries";
 import { MenuSelect } from "@/components/MenuSelect";
 import { GroupBase } from "react-select";
-import { useDebounce } from "@uidotdev/usehooks";
 import RegisterIdentity from "@/components/eip3643/admin/RegisterIdentity";
 import CreateIdentityFactory from "@/components/eip3643/admin/CreateIdentityFactory";
+import { useReadTokenName } from "@/hooks/useReadTokenName";
+import { useReadTokenIdentityRegistryQueries } from "@/hooks/useReadTokenIdentityRegistryQueries";
 
 export default function User() {
   const [tokenSelected, setTokenSelected] = useState<TokenNameItem>();
-  const [tokens, setTokens] = useState<TokenNameItem[]>([]);
   const { accountEvm } = useWalletInterface();
   const { deployedTokens } = useContext(Eip3643Context);
-  const { registriesAgents } = useTokensIdentityRegistries(tokens);
+  const { data: tokens, isSuccess: tokensIsSuccess } =
+    useReadTokenName(deployedTokens);
+
   const [tokensByOwnership, setTokensByOwnership] = useState<TokenNameItem[]>(
     [],
   );
-  const debouncedRegistriesAgents = useDebounce(registriesAgents, 5000);
+
+  const { data: tokenRegistries, isSuccess: registryAddressesIsSuccess } =
+    useReadTokenIdentityRegistryQueries(tokens);
+
+  const isReadyToLoadAgents = useMemo(() => {
+    return (
+      deployedTokens.length === tokens.length &&
+      tokens.length === tokenRegistries.length &&
+      tokensIsSuccess &&
+      registryAddressesIsSuccess
+    );
+  }, [
+    deployedTokens.length,
+    tokenRegistries.length,
+    registryAddressesIsSuccess,
+    tokens.length,
+    tokensIsSuccess,
+  ]);
+
+  const { registriesAgents } = useTokensIdentityRegistries(
+    tokenRegistries,
+    isReadyToLoadAgents,
+  );
 
   useEffect(() => {
-    (deployedTokens as any).map((item: any) => {
-      const tokenAddress = item["args"]?.[0];
-      tokenAddress &&
-        readTokenName({}, tokenAddress).then((res) => {
-          setTokens((prev) => {
-            return [
-              ...prev.filter((itemSub) => itemSub.address !== tokenAddress),
-              {
-                address: tokenAddress,
-                name: res[0],
-              },
-            ];
-          });
-        });
-    });
-  }, [deployedTokens, accountEvm, setTokens]);
+    if (!isReadyToLoadAgents) return;
 
-  useEffect(() => {
-    if (debouncedRegistriesAgents && accountEvm) {
+    if (registriesAgents && accountEvm) {
       setTokensByOwnership(
-        tokens.sort((a) => {
+        tokens.toSorted((a) => {
           const tokenIncludesIdentity =
-            debouncedRegistriesAgents[a.address]?.includes(accountEvm);
+            registriesAgents[a.address]?.includes(accountEvm);
 
           if (tokenIncludesIdentity) {
             return -1;
@@ -58,7 +65,7 @@ export default function User() {
     } else if (tokens) {
       setTokensByOwnership(tokens);
     }
-  }, [debouncedRegistriesAgents, accountEvm, tokens]);
+  }, [registriesAgents, accountEvm, tokens, isReadyToLoadAgents]);
 
   const handleTokenSelect = (value: string) => {
     const tokenItem = tokens.find((itemSub) => itemSub.address === value);
@@ -70,7 +77,7 @@ export default function User() {
       <Stack align="center">
         <Box width="50%">
           <MenuSelect
-            loadingInProgress={!tokensByOwnership?.length}
+            loadingInProgress={!isReadyToLoadAgents}
             data={
               tokensByOwnership.map((item) => ({
                 value: item.address,

--- a/src/contexts/Eip3643Context.tsx
+++ b/src/contexts/Eip3643Context.tsx
@@ -1,9 +1,16 @@
 import { LogDescription } from "ethers";
-import { createContext, ReactNode, useState } from "react";
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useState,
+} from "react";
+import { EvmAddress } from "@/types/types";
 
 type defaultContextType = {
-  deployedTokens: LogDescription[];
-  setDeployedTokens: (newValue: []) => void;
+  deployedTokens: EvmAddress[];
+  setDeployedTokens: Dispatch<SetStateAction<EvmAddress[]>>;
   identities: LogDescription[];
   setIdentities: (newValue: []) => void;
   currentIdentityAddress: string;

--- a/src/hooks/eip3643/useOwnTokens.ts
+++ b/src/hooks/eip3643/useOwnTokens.ts
@@ -1,0 +1,51 @@
+import { useReadTokenOwnerQueries } from "@/hooks/useReadTokenOwnerQueries";
+import { useContext, useEffect, useState } from "react";
+import { TokenNameItem, TokenOwnerItem } from "@/types/types";
+import { useReadTokenNameQueries } from "@/hooks/useReadTokenNameQueries";
+import { useWalletInterface } from "@/services/wallets/useWalletInterface";
+import { Eip3643Context } from "@/contexts/Eip3643Context";
+
+export function useOwnTokens() {
+  const { accountEvm } = useWalletInterface();
+  const { deployedTokens } = useContext(Eip3643Context);
+  const [ownTokens, setOwnTokens] = useState<TokenNameItem[]>([]);
+
+  const { data: tokensWithOwners, isSuccess: tokensWithOwnersSuccess } =
+    useReadTokenOwnerQueries(deployedTokens);
+
+  const [userOwnedTokens, setUserOwnedTokens] = useState<TokenOwnerItem[]>([]);
+
+  useEffect(() => {
+    if (tokensWithOwnersSuccess) {
+      setUserOwnedTokens(
+        tokensWithOwners
+          .filter(
+            (tokenOwnerItem): tokenOwnerItem is TokenOwnerItem =>
+              tokenOwnerItem !== undefined,
+          )
+          .filter(
+            (tokenOwnerItem) =>
+              tokenOwnerItem.ownerAddress?.toLowerCase() ===
+              accountEvm?.toLowerCase(),
+          ),
+      );
+    }
+  }, [accountEvm, tokensWithOwners, tokensWithOwnersSuccess]);
+
+  const { data: userOwnedTokensWithNames, isSuccess: tokensWithNamesSuccess } =
+    useReadTokenNameQueries(
+      userOwnedTokens.map((userOwnedToken) => userOwnedToken.tokenAddress),
+    );
+
+  useEffect(() => {
+    if (tokensWithNamesSuccess) {
+      setOwnTokens(
+        userOwnedTokensWithNames.filter(
+          (token): token is TokenNameItem => token !== undefined,
+        ),
+      );
+    }
+  }, [tokensWithNamesSuccess, userOwnedTokensWithNames]);
+
+  return { ownTokens };
+}

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,3 +1,5 @@
+import { useReadTokenIdentityRegistryQueries } from "@/hooks/useReadTokenIdentityRegistryQueries";
+
 export enum QueryKeys {
   ContractCallResults = "contractCallResults",
   ReadErc20BalanceOf = "readErc20BalanceOf",
@@ -13,6 +15,7 @@ export enum QueryKeys {
   ReadTokenOwner = "readTokenOwner",
   ReadIdentityRegistryInvestorCountry = "readIdentityRegistryInvestorCountry",
   ReadTokenTotalSupply = "readTokenTotalSupply",
+  ReadTokenIdentityRegistry = "readTokenIdentityRegistry",
 }
 
 export enum QueryKeysEIP4626 {

--- a/src/hooks/useReadTokenIdentityRegistryQueries.ts
+++ b/src/hooks/useReadTokenIdentityRegistryQueries.ts
@@ -1,0 +1,37 @@
+import { useQueries, UseQueryResult, skipToken } from "@tanstack/react-query";
+import { QueryKeys } from "@/hooks/types";
+import { readTokenIdentityRegistry } from "@/services/contracts/wagmiGenActions";
+import { TokenNameItem, TokenRegistry } from "@/types/types";
+
+const combineQueryResults = (results: UseQueryResult[]) => {
+  return {
+    data: results.map((result) => result.data as TokenRegistry),
+    isSuccess: results.every((result) => result.isSuccess),
+  };
+};
+
+export function useReadTokenIdentityRegistryQueries(
+  tokens: TokenNameItem[] | undefined[],
+) {
+  return useQueries({
+    // @ts-ignore
+    queries: tokens.map((token) => ({
+      queryKey: [QueryKeys.ReadTokenIdentityRegistry, token?.address],
+      queryFn: !token?.address
+        ? skipToken
+        : async () => {
+            const registryAddress = await readTokenIdentityRegistry(
+              { args: [] },
+              token.address,
+            );
+
+            return {
+              tokenAddress: token.address,
+              registryAddress: registryAddress,
+            };
+          },
+      staleTime: Infinity,
+    })),
+    combine: combineQueryResults,
+  });
+}

--- a/src/hooks/useReadTokenIdentityRegistryQueries.ts
+++ b/src/hooks/useReadTokenIdentityRegistryQueries.ts
@@ -11,7 +11,7 @@ const combineQueryResults = (results: UseQueryResult[]) => {
 };
 
 export function useReadTokenIdentityRegistryQueries(
-  tokens: TokenNameItem[] | undefined[],
+  tokens: (TokenNameItem | undefined)[],
 ) {
   return useQueries({
     // @ts-ignore
@@ -22,11 +22,11 @@ export function useReadTokenIdentityRegistryQueries(
         : async () => {
             const registryAddress = await readTokenIdentityRegistry(
               { args: [] },
-              token.address,
+              token?.address,
             );
 
             return {
-              tokenAddress: token.address,
+              tokenAddress: token?.address,
               registryAddress: registryAddress,
             };
           },

--- a/src/hooks/useReadTokenName.ts
+++ b/src/hooks/useReadTokenName.ts
@@ -1,20 +1,34 @@
-import { useQueries } from "@tanstack/react-query";
+import { useQueries, UseQueryResult } from "@tanstack/react-query";
 import { readTokenName } from "@/services/contracts/wagmiGenActions";
 import { QueryKeys } from "@/hooks/types";
 import { LogDescription } from "ethers";
+import { EvmAddress, TokenNameItem } from "@/types/types";
+
+/**
+ * Helper function to keep the return value of the useQueries hook
+ * as referentially stable and prevent re-renders of consumer components
+ * @see https://tanstack.com/query/latest/docs/framework/react/reference/useQueries#memoization
+ */
+const combineQueryResults = (results: UseQueryResult[]) => {
+  return {
+    data: results.map((result) => result.data as TokenNameItem),
+    isSuccess: results.every((result) => result.isSuccess),
+  };
+};
 
 export function useReadTokenName(tokenLogItems: LogDescription[]) {
   return useQueries({
     queries: tokenLogItems.map((tokenLogItem) => ({
       queryKey: [QueryKeys.ReadTokenName, tokenLogItem["args"]?.[0]],
       queryFn: async () => {
-        let tokenName = await readTokenName({}, tokenLogItem["args"]?.[0]);
+        const tokenName = await readTokenName({}, tokenLogItem["args"]?.[0]);
         return {
           name: tokenName.toString(),
-          address: tokenLogItem["args"]?.[0] as string,
+          address: tokenLogItem["args"]?.[0] as EvmAddress,
         };
       },
       staleTime: Infinity,
     })),
+    combine: combineQueryResults,
   });
 }

--- a/src/hooks/useReadTokenOwnerQueries.ts
+++ b/src/hooks/useReadTokenOwnerQueries.ts
@@ -1,0 +1,28 @@
+import { useQueries, UseQueryResult } from "@tanstack/react-query";
+import { EvmAddress, TokenOwnerItem } from "@/types/types";
+import { QueryKeys } from "@/hooks/types";
+import { readTokenOwner } from "@/services/contracts/wagmiGenActions";
+
+const combineQueryResults = (results: UseQueryResult[]) => {
+  return {
+    data: results.map((result) => result.data as TokenOwnerItem | undefined),
+    isSuccess: results.every((result) => result.isSuccess),
+  };
+};
+
+export function useReadTokenOwnerQueries(tokenAddresses: EvmAddress[]) {
+  return useQueries({
+    queries: tokenAddresses.map((tokenAddress) => ({
+      queryKey: [QueryKeys.ReadTokenOwner, tokenAddress],
+      queryFn: async () => {
+        const tokenOwner = await readTokenOwner({}, tokenAddress);
+        return {
+          tokenAddress: tokenAddress,
+          ownerAddress: tokenOwner.toString(),
+        };
+      },
+      staleTime: Infinity,
+    })),
+    combine: combineQueryResults,
+  });
+}

--- a/src/services/contracts/codegen/createWatchContractEvent.ts
+++ b/src/services/contracts/codegen/createWatchContractEvent.ts
@@ -61,6 +61,6 @@ export function createWatchContractEvent<
       ...(addressOverride ? { address: addressOverride } : {}),
       ...(c.eventName ? { eventName: c.eventName } : {}),
       abi: c.abi,
-    }) as any; // TODO
+    }) as any;
   };
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -29,8 +29,13 @@ export type AddIdentityToRegistryRequest = {
 };
 
 export type TokenNameItem = {
-  address: `0x${string}`;
+  address: EvmAddress;
   name: string;
+};
+
+export type TokenOwnerItem = {
+  tokenAddress: EvmAddress;
+  ownerAddress: EvmAddress;
 };
 
 export type TokenRegistry = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -33,6 +33,11 @@ export type TokenNameItem = {
   name: string;
 };
 
+export type TokenRegistry = {
+  tokenAddress: EvmAddress;
+  registryAddress: EvmAddress;
+};
+
 export type TransferTokenFromRequest = {
   tokenAddress: `0x${string}`;
   toAddress: `0x${string}`;

--- a/src/views/eip3643/EIP3643.tsx
+++ b/src/views/eip3643/EIP3643.tsx
@@ -57,18 +57,12 @@ export default function EIP3643() {
           <TabPanel>
             <User />
           </TabPanel>
-          <TabPanel>
-            <Admin />
-          </TabPanel>
+          <TabPanel>{/*<Admin />*/}</TabPanel>
           <TabPanel>
             <NFT />
           </TabPanel>
-          <TabPanel>
-            <ManageRegistry isAgents={false} />
-          </TabPanel>
-          <TabPanel>
-            <ManageRegistry isAgents />
-          </TabPanel>
+          <TabPanel>{/*<ManageRegistry isAgents={false} />*/}</TabPanel>
+          <TabPanel>{/*<ManageRegistry isAgents />*/}</TabPanel>
         </TabPanels>
       </Tabs>
     </>

--- a/src/views/eip3643/EIP3643.tsx
+++ b/src/views/eip3643/EIP3643.tsx
@@ -12,6 +12,7 @@ import { WatchContractEventReturnType } from "viem";
 import NoWalletConnected from "@/components/NoWalletConnected";
 import NFT from "@/components/eip3643/NFT";
 import { ManageRegistry } from "@/components/manage-registry/ManageRegistry";
+import { EvmAddress } from "@/types/types";
 
 export default function EIP3643() {
   const { accountId } = useWalletInterface();
@@ -22,9 +23,14 @@ export default function EIP3643() {
     const unsubTokens: WatchContractEventReturnType =
       watchTrexFactoryTrexSuiteDeployedEvent({
         onLogs: (data) => {
-          setDeployedTokens(((prev: any) => {
-            return [...prev, ...data];
-          }) as any);
+          setDeployedTokens((prev) => {
+            return [
+              ...prev,
+              ...data
+                .map(({ args }) => args._token)
+                .filter((token): token is EvmAddress => token !== undefined),
+            ];
+          });
         },
       });
     const unsubIdentities: WatchContractEventReturnType =
@@ -45,7 +51,7 @@ export default function EIP3643() {
 
   return (
     <>
-      <Tabs>
+      <Tabs isLazy>
         <TabList>
           <Tab>User Area</Tab>
           <Tab>Admin Area</Tab>
@@ -57,7 +63,9 @@ export default function EIP3643() {
           <TabPanel>
             <User />
           </TabPanel>
-          <TabPanel>{/*<Admin />*/}</TabPanel>
+          <TabPanel>
+            <Admin />
+          </TabPanel>
           <TabPanel>
             <NFT />
           </TabPanel>

--- a/src/views/eip3643/EIP3643.tsx
+++ b/src/views/eip3643/EIP3643.tsx
@@ -69,8 +69,12 @@ export default function EIP3643() {
           <TabPanel>
             <NFT />
           </TabPanel>
-          <TabPanel>{/*<ManageRegistry isAgents={false} />*/}</TabPanel>
-          <TabPanel>{/*<ManageRegistry isAgents />*/}</TabPanel>
+          <TabPanel>
+            <ManageRegistry isAgents={false} />
+          </TabPanel>
+          <TabPanel>
+            <ManageRegistry isAgents />
+          </TabPanel>
         </TabPanels>
       </Tabs>
     </>


### PR DESCRIPTION
- prevent RPC overload with cutting down from thousands of requests to less than 1k (atm) initial ones, considering we already have more that 50 tokens deployed
- switch to lazy loading tabs to prevent loading data we dont need initially
- switch to using hook with queries to optimise the way we load token names and owners.
- add new improved queries for loading token registries and identities.
- add bunch of data cleanup with better TS types